### PR TITLE
Assorted improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,45 @@
             <artifactId>twitter4j-core</artifactId>
             <version>[3.0,)</version>
         </dependency>
+
+        <!-- Unirest and its dependencies -->
+        <dependency>
+            <groupId>com.mashape.unirest</groupId>
+            <artifactId>unirest-java</artifactId>
+            <version>1.3.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+            <version>4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>4.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20131018</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>LATEST</version>
+        </dependency>
+
+        <!-- Reflections framework -->
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.9-RC1</version>
+        </dependency>
     </dependencies>
 
     <!-- Build -->
@@ -137,18 +176,25 @@
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <minimizeJar>true</minimizeJar>
-                            <artifactSet>
-                                <includes>
-                                    <include>org.pircbotx:pircbotx</include>
-                                    <include>com.google.code.gson:gson</include>
-                                    <include>org.yaml:snakeyaml</include>
-                                    <include>org.twitter4j:twitter4j-core</include>
-                                </includes>
-                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>log4j:log4j</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>commons-logging:commons-logging</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+
 
             <!-- Jar-Filler -->
             <plugin>

--- a/src/main/java/com/dsh105/nexus/Nexus.java
+++ b/src/main/java/com/dsh105/nexus/Nexus.java
@@ -25,6 +25,11 @@ import com.dsh105.nexus.hook.jenkins.Jenkins;
 import com.dsh105.nexus.listener.EventManager;
 import com.dsh105.nexus.response.ResponseManager;
 import com.dsh105.nexus.util.JsonUtil;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.async.Callback;
+import com.mashape.unirest.http.exceptions.UnirestException;
 import org.pircbotx.Channel;
 import org.pircbotx.PircBotX;
 import org.pircbotx.User;
@@ -32,8 +37,10 @@ import org.pircbotx.exception.IrcException;
 import org.pircbotx.exception.NickAlreadyInUseException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.Future;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,6 +58,7 @@ public class Nexus extends PircBotX {
     private ResponseManager responseManager;
     private Jenkins jenkins;
     private GitHub github;
+
 
     public static void main(String[] args) throws Exception {
         new Nexus();
@@ -99,6 +107,13 @@ public class Nexus extends PircBotX {
 
     private void connect() {
         try {
+            if (!this.config.isReady()) {
+                LOGGER.info("Your config needs the 'ready' field to set to true.");
+                System.exit(-1);
+            }
+
+            LOGGER.info("Attempting to connect to " + this.config.getServer());
+
             this.connect(this.config.getServer(), this.config.getPort(), this.config.getAccountPassword());
             for (String channel : this.config.getChannels()) {
                 this.joinChannel(channel);

--- a/src/main/java/com/dsh105/nexus/command/CommandManager.java
+++ b/src/main/java/com/dsh105/nexus/command/CommandManager.java
@@ -19,21 +19,34 @@ package com.dsh105.nexus.command;
 
 import com.dsh105.nexus.Nexus;
 import com.dsh105.nexus.command.module.HelpCommand;
+import com.dsh105.nexus.command.module.HttpTestCommand;
 import com.dsh105.nexus.command.module.StackTestCommand;
 import org.pircbotx.Channel;
 import org.pircbotx.Colors;
 import org.pircbotx.User;
+import org.reflections.Reflections;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Set;
 
 public class CommandManager {
 
     private ArrayList<CommandModule> modules = new ArrayList<>();
 
     public void registerDefaults() {
-        this.register(new HelpCommand());
-        this.register(new StackTestCommand());
+        Reflections reflections = new Reflections("com.dsh105.nexus.command.module");
+        Set<Class<? extends CommandModule>> cmds = reflections.getSubTypesOf(CommandModule.class);
+        for (Class<? extends CommandModule> cmd : cmds) {
+            try {
+                this.register(cmd.newInstance());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
     }
 
     public void register(CommandModule module) {

--- a/src/main/java/com/dsh105/nexus/command/module/HelpCommand.java
+++ b/src/main/java/com/dsh105/nexus/command/module/HelpCommand.java
@@ -30,9 +30,8 @@ public class HelpCommand extends CommandModule {
     public boolean onCommand(CommandPerformEvent event) {
         for (CommandModule module : Nexus.getInstance().getCommandManager().getRegisteredCommands()) {
             event.respond(Colors.BOLD + Nexus.getInstance().getConfig().getCommandPrefix() + module.getCommand() + Colors.NORMAL + " - " + module.getHelp(), true);
-            return true;
         }
-        return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/com/dsh105/nexus/command/module/HttpTestCommand.java
+++ b/src/main/java/com/dsh105/nexus/command/module/HttpTestCommand.java
@@ -1,0 +1,37 @@
+package com.dsh105.nexus.command.module;
+
+import com.dsh105.nexus.command.Command;
+import com.dsh105.nexus.command.CommandModule;
+import com.dsh105.nexus.command.CommandPerformEvent;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+
+@Command(command = "httptest", needsChannel = false)
+public class HttpTestCommand extends CommandModule {
+
+    @Override
+    public boolean onCommand(CommandPerformEvent event) {
+        /**
+         * This is a very simple example of how to use UniRest with a JSON
+         * endpoint and extract some data. Obviously, if this were a real
+         * command you wouldn't be hardcoding user agents or handling exceptions
+         * like this. You'd also be doing this all async.
+         */
+        String url = "http://httpbin.org/user-agent";
+        try {
+            Unirest.setDefaultHeader("User-Agent", "Nexus/v1.0 (by DSH105)");
+            HttpResponse<JsonNode> jsonResponse = Unirest.get(url)
+                    .asJson();
+            event.respond(jsonResponse.getBody().getObject().getString("user-agent"));
+        } catch (UnirestException e) {
+            e.printStackTrace();
+            event.respond("Oh no! Something went wrong: " + e.getMessage());
+        }
+        return true;
+    }
+
+    @Override
+    public String getHelp() { return "Tests a simple HTTP request."; }
+}

--- a/src/main/java/com/dsh105/nexus/config/OptionsConfig.java
+++ b/src/main/java/com/dsh105/nexus/config/OptionsConfig.java
@@ -52,6 +52,7 @@ public class OptionsConfig extends YamlConfig {
         this.options.put("github-key", "");
         this.options.put("channels", channels);
         this.options.put("admins", admins);
+        this.options.put("ready", false);
     }
 
     @Override
@@ -68,6 +69,8 @@ public class OptionsConfig extends YamlConfig {
     public int getPort() {
         return get("port", 5555);
     }
+
+    public boolean isReady() { return get("ready", false); }
 
     public String getAccountPassword() {
         return get("account-password", "");


### PR DESCRIPTION
> Fix help command, add reflection based command registration, add UniRest library, add example HTTP command, enforce config editing before operation.

**The Issues**
- Help command only showed one command, even if more were registered.
- Command registration was cumbersome and required modifying the CommandManager for every new command added.
- HTTP code wasn't as simple as it could have been. I've added UniRest to try and address this.
- There was no way to stop bot connecting to EsperNet on first run.

**Justification for this PR:**
- A help command should show help for all commands - it's kinda the point of the command.
- The reflection-based command registration requires you to simply make a class in the modules package for it to be automatically registered.
- There's no reason why people may not wish to use EsperNet as their primary IRC server - this should be configurable from the start.

**PR Breakdown**
- I fixed the help command by stopping the return statement breaking out of the loop.
- I've added the 'Reflections' framework to get all classes in the appropriate package that extend the base command class. These are then registered on startup.
- I've added UniRest and made quite a few changes to the POM in order to get it to work (minimizeJar actually breaks the logging library unless you tell it not to mess with it).

**Relevant PR(s) and Issue(s)**
Not applicable.
