### PR TITLE
Add currency conversion command and some other fixes

### DIFF
--- a/src/main/java/com/dsh105/nexus/command/CommandManager.java
+++ b/src/main/java/com/dsh105/nexus/command/CommandManager.java
@@ -28,6 +28,7 @@ import org.pircbotx.User;
 import org.reflections.Reflections;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -67,7 +68,7 @@ public class CommandManager {
 
     public CommandModule getModuleFor(String commandArguments) {
         for (CommandModule module : modules) {
-            if (module.getCommandInfo().command().equalsIgnoreCase(commandArguments)) {
+            if (module.getCommandInfo().command().equalsIgnoreCase(commandArguments) || Arrays.asList(module.getCommandInfo().aliases()).contains(commandArguments.toLowerCase())) {
                 return module;
             }
         }

--- a/src/main/java/com/dsh105/nexus/command/module/CurrencyCommand.java
+++ b/src/main/java/com/dsh105/nexus/command/module/CurrencyCommand.java
@@ -1,0 +1,45 @@
+package com.dsh105.nexus.command.module;
+
+import com.dsh105.nexus.command.Command;
+import com.dsh105.nexus.command.CommandModule;
+import com.dsh105.nexus.command.CommandPerformEvent;
+import com.dsh105.nexus.exception.currency.CurrencyException;
+import com.dsh105.nexus.util.StringUtil;
+import com.dsh105.nexus.util.currency.CurrencyConverter;
+import com.dsh105.nexus.util.currency.RateExchangeLookup;
+
+@Command(command = "currency", aliases = {"cur"}, needsChannel = false, help = "Converts between two currencies.",
+        extendedHelp = {
+                "This command allows conversion between two currencies. A list of currency codes is available at http://www.xe.com/currency/",
+                "{from} {to} {amount} - where 'from' and 'to' are valid currency codes.",
+                "Data is provided with no guarantees whatsoever."})
+public class CurrencyCommand extends CommandModule {
+
+    @Override
+    public boolean onCommand(CommandPerformEvent event) {
+        final String[] args = event.getArgs();
+        if (args.length != 3) {
+            return false;
+        }
+        
+        String from = args[0];
+        String to = args[1];
+        String amountStr = args[2];
+
+        if (!StringUtil.isDouble(amountStr)) {
+            event.respond("Amount is not a valid value.");
+            return false;
+        }
+
+        double amount = Double.parseDouble(amountStr);
+
+        try {
+            CurrencyConverter converter = new CurrencyConverter(new RateExchangeLookup());
+            double newAmount = CurrencyConverter.roundToPennies(converter.convertAmount(amount, from, to));
+            event.respond(String.format("%.2f %s is %.2f %s to the nearest penny.", amount, from, newAmount, to));
+        } catch (CurrencyException exception) {
+            event.respond("Conversion failed. Check currency codes are correct and try again.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/dsh105/nexus/exception/currency/CurrencyException.java
+++ b/src/main/java/com/dsh105/nexus/exception/currency/CurrencyException.java
@@ -1,0 +1,4 @@
+package com.dsh105.nexus.exception.currency;
+
+public abstract class CurrencyException extends Exception {
+}

--- a/src/main/java/com/dsh105/nexus/exception/currency/CurrencyLookupException.java
+++ b/src/main/java/com/dsh105/nexus/exception/currency/CurrencyLookupException.java
@@ -1,0 +1,4 @@
+package com.dsh105.nexus.exception.currency;
+
+public class CurrencyLookupException extends CurrencyException {
+}

--- a/src/main/java/com/dsh105/nexus/exception/currency/InvalidCurrencyException.java
+++ b/src/main/java/com/dsh105/nexus/exception/currency/InvalidCurrencyException.java
@@ -1,0 +1,4 @@
+package com.dsh105.nexus.exception.currency;
+
+public class InvalidCurrencyException extends CurrencyException  {
+}

--- a/src/main/java/com/dsh105/nexus/util/StringUtil.java
+++ b/src/main/java/com/dsh105/nexus/util/StringUtil.java
@@ -39,6 +39,21 @@ public class StringUtil {
     }
 
     /**
+     * Tests if the given String is an Double
+     *
+     * @param string the String to be checked
+     * @return true if Double
+     */
+    public static boolean isDouble(String string) {
+        try {
+            Double.parseDouble(string);
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Capitalizes the first letter of a String
      *
      * @param string the String to be capitalized

--- a/src/main/java/com/dsh105/nexus/util/currency/CurrencyConverter.java
+++ b/src/main/java/com/dsh105/nexus/util/currency/CurrencyConverter.java
@@ -1,0 +1,25 @@
+package com.dsh105.nexus.util.currency;
+
+import com.dsh105.nexus.exception.currency.CurrencyException;
+
+import java.math.BigDecimal;
+
+public class CurrencyConverter {
+
+    private CurrencyLookupInterface lookup;
+
+    public CurrencyConverter(CurrencyLookupInterface lookupInterface) {
+        this.lookup = lookupInterface;
+    }
+
+    public double convertAmount(double amount, String from, String to) throws CurrencyException {
+        return this.lookup.getExchangeRate(from, to) * amount;
+    }
+
+    public static double roundToPennies(double amount) {
+        BigDecimal bd = new BigDecimal(amount);
+        BigDecimal rounded = bd.setScale(2, BigDecimal.ROUND_HALF_UP);
+        return rounded.doubleValue();
+    }
+
+}

--- a/src/main/java/com/dsh105/nexus/util/currency/CurrencyLookupInterface.java
+++ b/src/main/java/com/dsh105/nexus/util/currency/CurrencyLookupInterface.java
@@ -1,0 +1,7 @@
+package com.dsh105.nexus.util.currency;
+
+import com.dsh105.nexus.exception.currency.CurrencyException;
+
+public interface CurrencyLookupInterface {
+    public double getExchangeRate(String from, String to) throws CurrencyException;
+}

--- a/src/main/java/com/dsh105/nexus/util/currency/RateExchangeLookup.java
+++ b/src/main/java/com/dsh105/nexus/util/currency/RateExchangeLookup.java
@@ -1,0 +1,28 @@
+package com.dsh105.nexus.util.currency;
+
+import com.dsh105.nexus.exception.currency.CurrencyException;
+import com.dsh105.nexus.exception.currency.CurrencyLookupException;
+import com.dsh105.nexus.exception.currency.InvalidCurrencyException;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+
+public class RateExchangeLookup implements CurrencyLookupInterface {
+
+    public static final String API_URL = "http://rate-exchange.appspot.com/currency";
+
+    @Override
+    public double getExchangeRate(String from, String to) throws CurrencyException {
+        try {
+            HttpResponse<JsonNode> resp = Unirest.get(API_URL).field("to", to).field("from", from).asJson();
+            if (resp.getBody().getObject().has("err")) {
+                throw new InvalidCurrencyException();
+            } else {
+                return resp.getBody().getObject().getDouble("rate");
+            }
+        } catch (UnirestException e) {
+            throw new CurrencyLookupException();
+        }
+    }
+}

--- a/src/test/java/com/dsh105/nexus/currency/CurrencyTest.java
+++ b/src/test/java/com/dsh105/nexus/currency/CurrencyTest.java
@@ -1,0 +1,26 @@
+package com.dsh105.nexus.currency;
+
+import com.dsh105.nexus.exception.currency.CurrencyException;
+import com.dsh105.nexus.mock.MockLookup;
+import com.dsh105.nexus.util.currency.CurrencyConverter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CurrencyTest {
+
+    @Test
+    public void testConverterSimple() {
+        CurrencyConverter converter = new CurrencyConverter(new MockLookup(1));
+        try {
+            Assert.assertEquals("Converter uses Lookup system's exchange rate correctly.", converter.convertAmount(2d, "XYZ", "XYZ"), 2d, 0d);
+        } catch (CurrencyException e) {
+            Assert.fail("Currency exception.");
+        }
+    }
+
+    @Test
+    public void testConverterRounding() throws CurrencyException {
+        Assert.assertEquals("Rounding works correctly.", 2.51d, CurrencyConverter.roundToPennies(2.51235d), 0.005d);
+    }
+
+}

--- a/src/test/java/com/dsh105/nexus/mock/MockLookup.java
+++ b/src/test/java/com/dsh105/nexus/mock/MockLookup.java
@@ -1,0 +1,18 @@
+package com.dsh105.nexus.mock;
+
+import com.dsh105.nexus.exception.currency.CurrencyException;
+import com.dsh105.nexus.util.currency.CurrencyLookupInterface;
+
+public class MockLookup implements CurrencyLookupInterface {
+
+    private int multipicationRate;
+
+    public MockLookup(int multipicationRate) {
+        this.multipicationRate = multipicationRate;
+    }
+
+    @Override
+    public double getExchangeRate(String from, String to) throws CurrencyException {
+        return multipicationRate;
+    }
+}

--- a/src/test/java/com/dsh105/nexus/util/StringUtilTest.java
+++ b/src/test/java/com/dsh105/nexus/util/StringUtilTest.java
@@ -12,8 +12,16 @@ public class StringUtilTest {
 
     @Test
     public void testIsInt() {
-        Assert.assertTrue("Valid numeric string deemed integer", StringUtil.isInt("1"));
-        Assert.assertFalse("InValid numeric string deemed not an integer.", StringUtil.isInt("g"));
+        Assert.assertTrue("Valid numeric string deemed integer.", StringUtil.isInt("1"));
+        Assert.assertFalse("Invalid numeric string deemed not an integer.", StringUtil.isInt("g"));
+        Assert.assertFalse("Invalid decimal string deemed not an integer.", StringUtil.isInt("1.4"));
+    }
+
+    @Test
+    public void testIsDouble() {
+        Assert.assertTrue("Valid decimal string deemed double.", StringUtil.isDouble("1.4"));
+        Assert.assertTrue("Valid numeric string deemed double.", StringUtil.isDouble("1"));
+        Assert.assertFalse("Invalid numeric string deemed not a double.", StringUtil.isDouble("g"));
     }
 
     @Test


### PR DESCRIPTION
**The Issue**
The bot includes no method to convert currencies. This command adds this functionality. Additionally, I noticed aliases were not functional during development and fixed the issue.

**Justification for this PR:**
In IRC channels with multiple users from different locations, currency conversion can be useful.

**PR Breakdown**
- Adds a rate lookup interface an an implementation.
- Adds unit tests for the Converter class.
- Adds some util methods to the StringUtil class and appropriate tests.

**IRC Log**

``` irc
<@lol768> \cur GBP EUR 5
<Nexus> 5.00 GBP is 6.10 EUR to the nearest penny.
<@lol768> \cur GBP USD 5
<Nexus> 5.00 GBP is 8.49 USD to the nearest penny.
<@lol768> \cur USD GBP 25
<Nexus> 25.00 USD is 14.72 GBP to the nearest penny.
```
