### PR TITLE
Add URL to Travis's API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ Todo List
   * For example, retrieving information on specific users
   * Currently per-user authentication with GitHub is implemented (see `ghkey` command). Maybe there's a nicer way to do this instead of having to post Nexus the link?
 * Plenty more commands
-* Travis integration
+* Travis integration ([Click for more information](http://docs.travis-ci.com/api/))


### PR DESCRIPTION
**The Issue**
Currently, the TODO list specifies a want for the Travis CI to be implemented. A link to it's API will/would be handy for developers.

**Justification for this PR:**
To see if DSH105 will read this part.
