### PR TITLE
Disallow negative reminder time periods, fix time util to not recognise non-0-9 digits.

### DIFF
--- a/src/main/java/com/dsh105/nexus/command/module/general/RemindCommand.java
+++ b/src/main/java/com/dsh105/nexus/command/module/general/RemindCommand.java
@@ -48,12 +48,13 @@ public class RemindCommand extends CommandModule {
         if (event.getArgs().length >= 2) {
             long timePeriod = -1;
             boolean forOtherUser = false;
+            final String timeString = event.getArgs()[1];
             try {
-                timePeriod = TimeUtil.parse(event.getArgs()[1]);
+                timePeriod = TimeUtil.parse(timeString);
                 if (timePeriod > 0) {
                     forOtherUser = true;
                 }
-            } catch (NumberFormatException e) {
+            } catch (NumberFormatException ignored) {
             }
 
             String userToRemind = forOtherUser ? event.getArgs()[0] : event.getSender().getNick();
@@ -61,10 +62,10 @@ public class RemindCommand extends CommandModule {
             if (!forOtherUser) {
                 try {
                     timePeriod = TimeUtil.parse(event.getArgs()[0]);
-                } catch (NumberFormatException e) {
+                } catch (NumberFormatException ignored) {
                 }
             }
-            if (timePeriod <= 0) {
+            if (timePeriod <= 0 || timeString.contains("-")) {
                 event.respondWithPing("Invalid time period entered: {0}. Examples: {1} (1 day), {2} (2 hours), {3} (5 minutes, 30 seconds), {4} (1 week, 3 days)", event.getArgs()[0], "1d", "2h", "5m30s", "1w3d");
                 return true;
             }

--- a/src/main/java/com/dsh105/nexus/util/TimeUtil.java
+++ b/src/main/java/com/dsh105/nexus/util/TimeUtil.java
@@ -30,7 +30,7 @@ public class TimeUtil {
         String number = "";
         for (int i = 0; i < input.length(); i++) {
             char c = input.charAt(i);
-            if (Character.isDigit(c)) {
+            if (c >= '0' && c <= '9') {
                 number += c;
             } else if (Character.isLetter(c) && !number.isEmpty()) {
                 result += convert(Integer.parseInt(number), c);


### PR DESCRIPTION
**The Issue**
Negative time periods were parsed with negative signs being ignored. TimeUtil class failed to reject digits that didn't fit into the 0-9 category. 

**Justification for this PR:**
Because insufficient user feedback given when using time periods in the past.

**PR Breakdown**
Switches to a simpler comparison to check for 0-9 characters in TimeUtil class. Checks for use of '-' character in time string.
