### PR TITLE
Add option to disable command

### DIFF
--- a/src/main/java/com/dsh105/nexus/command/Command.java
+++ b/src/main/java/com/dsh105/nexus/command/Command.java
@@ -35,4 +35,6 @@ public @interface Command {
     public String help();
 
     public String[] helpGroups() default "all";
+
+    public boolean disabled() default false;
 }

--- a/src/main/java/com/dsh105/nexus/command/CommandManager.java
+++ b/src/main/java/com/dsh105/nexus/command/CommandManager.java
@@ -68,6 +68,10 @@ public class CommandManager {
             Nexus.LOGGER.warning("Failed to register command: " + module.getClass().getSimpleName() + ". Missing @Command annotation!");
             return;
         }
+        if (module.getCommandInfo().disabled()) {
+            Nexus.LOGGER.warning("Command " + module.getClass().getSimpleName() + " is disabled!");
+            return;
+        }
         this.modules.add(module);
     }
 

--- a/src/main/java/com/dsh105/nexus/command/module/bukkit/BukkitUser.java
+++ b/src/main/java/com/dsh105/nexus/command/module/bukkit/BukkitUser.java
@@ -4,7 +4,6 @@ import com.dsh105.nexus.command.Command;
 import com.dsh105.nexus.command.CommandModule;
 import com.dsh105.nexus.command.CommandPerformEvent;
 import com.dsh105.nexus.exception.bukkit.BukkitUserException;
-import com.dsh105.nexus.exception.currency.DogeCoinException;
 import com.dsh105.nexus.util.shorten.URLShortener;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -24,7 +23,6 @@ import java.util.Date;
         needsChannel = false,
         help = "Bukkit user profile info",
         extendedHelp = {"{b}{p}{c}{/b} <user> - Shows a Bukkit user's profile information"})
-
 public class BukkitUser extends CommandModule {
     @Override
     public boolean onCommand(CommandPerformEvent event) {


### PR DESCRIPTION
Now, this PR stems from the recent \insult incident. For much bigger commands, it would be nice for a way to disable them, rather then delete the class (and the code). One example would be for a service that needs to be improved. e.g. weather, say it breaks and a resolution cannot be found quickly. This would be a good(enough) solution.
