### PR TITLE
pircbotx is getting an incorrect total number of users.

### DIFF
--- a/src/main/java/com/dsh105/nexus/command/module/irc/ChannelStatsCommand.java
+++ b/src/main/java/com/dsh105/nexus/command/module/irc/ChannelStatsCommand.java
@@ -51,7 +51,7 @@ public class ChannelStatsCommand extends CommandModule {
         int numUsers = chan.getUsers().size();
         int numOpped = chan.getOps().size();
         int numVoiced = chan.getVoices().size();
-
+        numUsers = numUsers - numOpped;
         int opPercentage = Math.round(((float) numOpped / numUsers) * 100);
         int voicePercentage = Math.round(((float) numVoiced / numUsers) * 100);
 


### PR DESCRIPTION
The output of the command in its current state can be seen here: ![image](https://cloud.githubusercontent.com/assets/1421744/4329531/87859600-3f9b-11e4-9793-069ce620032d.png)
However, if we look to the user list: 
![image](https://cloud.githubusercontent.com/assets/1421744/4329533/9955127a-3f9b-11e4-85ad-8fc1849d6ccb.png) 

The ops amount + total user amount = the amount pircbotx seems to be getting. To make sure of this I manually counted the amount of users to make sure it was not an error on hexchat's behalf.
